### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-#JWT
-##项目介绍
-###预备知识（可能需要科学上网）
+# JWT
+## 项目介绍
+### 预备知识（可能需要科学上网）
 + <a href="http://blog.leapoahead.com/2015/09/06/understanding-jwt/" target="_blank">JSON Web Token（JWT)是什么鬼</a>
 + <a href="http://blog.leapoahead.com/2015/09/07/user-authentication-with-jwt/" target="_blank">八幅漫画理解使用JSON Web Token设计单点登录系统</a>
 
-###流程图
+### 流程图
 ![image](https://github.com/bigmeow/JWT/blob/master/WebRoot/flowsheet.JPG)
-###目录结构
+### 目录结构
 ```
 .
 ├── README.md
@@ -29,7 +29,7 @@
 |	|── main.html
 |   └── jquery-2.1.0.js
 ```
-##由于使用了servlet3.0语法，运行环境要求JDK7以及以上，Tomcat7以及以上<s>（ 根目录下附带降级版本，支持jdk1.6,tomcat6 ,暂不可用，有空再更新） </s>
+## 由于使用了servlet3.0语法，运行环境要求JDK7以及以上，Tomcat7以及以上<s>（ 根目录下附带降级版本，支持jdk1.6,tomcat6 ,暂不可用，有空再更新） </s>
 本项目依赖于下面jar包：
 + nimbus-jose-jwt-4.13.1.jar (一款开源的成熟的JSON WEB TOKEN 解决方法，本仓库的代码是对其的进一步封装)
 + json-smart-2.0-RC2.jar和asm-1.0-RC1.jar (依赖jar包，主要用于JSONObject序列化)
@@ -46,8 +46,8 @@
 
    
    
-##使用示例
-###获取token
+## 使用示例
+### 获取token
 
 ```Java
 Map<String , Object> payload=new HashMap<String, Object>();
@@ -60,7 +60,7 @@ System.out.println("token:"+token);
 
 ```
 
-###校验token
+### 校验token
 ```Java
 
 String token="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOiIyOTE5Njk0NTIiLCJpYXQiOjE0NjA0MzE4ODk2OTgsImV4dCI6MTQ2MDQzNTQ4OTY5OH0.RAa71BnklRMPyPhYBbxsfJdtXBnXeWevxcXLlwC2PrY";
@@ -86,5 +86,5 @@ System.out.println("返回结果数据是：" +result.toString());
 
 ```
 
-##一些坑
+## 一些坑
 跨域过滤器一定要比其他过滤器先执行，不然会有些问题：在web.xml文件中，过滤器的执行顺序是按照在web.xml中从上到下书写的顺序来执行的；在servlet3.0注解中，filter执行顺序是按照文件名自然排序来决定执行顺序的，比如名字叫A的filter就比B先执行


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
